### PR TITLE
🪲  make Reality template IDs vary through the factory

### DIFF
--- a/src/FlatCFMOracleAdapter.sol
+++ b/src/FlatCFMOracleAdapter.sol
@@ -4,12 +4,13 @@ pragma solidity 0.8.20;
 import {FlatCFMQuestionParams, GenericScalarQuestionParams} from "./Types.sol";
 
 abstract contract FlatCFMOracleAdapter {
-    function askDecisionQuestion(FlatCFMQuestionParams calldata flatCFMQuestionParams)
+    function askDecisionQuestion(uint256 decisionTemplateId, FlatCFMQuestionParams calldata flatCFMQuestionParams)
         external
         virtual
         returns (bytes32);
 
     function askMetricQuestion(
+        uint256 metricTemplateId,
         GenericScalarQuestionParams calldata genericScalarQuestionParams,
         string memory outcomeName
     ) external virtual returns (bytes32);

--- a/src/FlatCFMRealityAdapter.sol
+++ b/src/FlatCFMRealityAdapter.sol
@@ -16,23 +16,12 @@ contract FlatCFMRealityAdapter is FlatCFMOracleAdapter {
 
     IRealityETH public immutable oracle;
     address public immutable arbitrator;
-    uint256 public immutable decisionTemplateId;
-    uint256 public immutable metricTemplateId;
     uint32 public immutable questionTimeout;
     uint256 public immutable minBond;
 
-    constructor(
-        IRealityETH _oracle,
-        address _arbitrator,
-        uint256 _decisionTemplateId,
-        uint256 _metricTemplateId,
-        uint32 _questionTimeout,
-        uint256 _minBond
-    ) {
+    constructor(IRealityETH _oracle, address _arbitrator, uint32 _questionTimeout, uint256 _minBond) {
         oracle = _oracle;
         arbitrator = _arbitrator;
-        decisionTemplateId = _decisionTemplateId;
-        metricTemplateId = _metricTemplateId;
         questionTimeout = _questionTimeout;
         minBond = _minBond;
     }
@@ -69,7 +58,6 @@ contract FlatCFMRealityAdapter is FlatCFMOracleAdapter {
         );
     }
 
-    /// @dev This is the only function known by higher level contracts.
     /// @return The ID of the newly created Reality question.
     function _askQuestion(
         uint256 templateId,
@@ -94,7 +82,7 @@ contract FlatCFMRealityAdapter is FlatCFMOracleAdapter {
         );
     }
 
-    function askDecisionQuestion(FlatCFMQuestionParams calldata flatCFMQuestionParams)
+    function askDecisionQuestion(uint256 decisionTemplateId, FlatCFMQuestionParams calldata flatCFMQuestionParams)
         public
         override
         returns (bytes32)
@@ -104,6 +92,7 @@ contract FlatCFMRealityAdapter is FlatCFMOracleAdapter {
     }
 
     function askMetricQuestion(
+        uint256 metricTemplateId,
         GenericScalarQuestionParams calldata genericScalarQuestionParams,
         string memory outcomeName
     ) public override returns (bytes32) {

--- a/test/CFMRealityAdapter.t.sol
+++ b/test/CFMRealityAdapter.t.sol
@@ -22,21 +22,13 @@ contract CFMRealityAdapterWithMockTest is Test {
     function setUp() public {
         fakeRealityEth = new FakeRealityETH();
         conditionalTokens = new ConditionalTokens();
-        realityAdapter = new FlatCFMRealityAdapter(
-            IRealityETH(address(fakeRealityEth)),
-            arbitrator,
-            decisionTemplateId,
-            metricTemplateId,
-            questionTimeout,
-            minBond
-        );
+        realityAdapter =
+            new FlatCFMRealityAdapter(IRealityETH(address(fakeRealityEth)), arbitrator, questionTimeout, minBond);
     }
 
     function testConstructor() public view {
         assertEq(address(realityAdapter.oracle()), address(fakeRealityEth));
         assertEq(realityAdapter.arbitrator(), arbitrator);
-        assertEq(realityAdapter.decisionTemplateId(), decisionTemplateId);
-        assertEq(realityAdapter.metricTemplateId(), metricTemplateId);
         assertEq(realityAdapter.questionTimeout(), questionTimeout);
         assertEq(realityAdapter.minBond(), minBond);
     }
@@ -55,7 +47,7 @@ contract CFMRealityAdapterWithMockTest is Test {
             abi.encodeWithSelector(FakeRealityETH.askQuestionWithMinBond.selector),
             abi.encode(bytes32("fakeDecisionQuestionId"))
         );
-        bytes32 questionId = realityAdapter.askDecisionQuestion(flatCFMQuestionParams);
+        bytes32 questionId = realityAdapter.askDecisionQuestion(decisionTemplateId, flatCFMQuestionParams);
 
         // TODO: add integrated test.
         assertEq(questionId, bytes32("fakeDecisionQuestionId"));
@@ -75,7 +67,7 @@ contract CFMRealityAdapterWithMockTest is Test {
             abi.encodeWithSelector(FakeRealityETH.askQuestionWithMinBond.selector),
             abi.encode(bytes32("fakeMetricQuestionId"))
         );
-        bytes32 questionId = realityAdapter.askMetricQuestion(params, "Above $2000");
+        bytes32 questionId = realityAdapter.askMetricQuestion(metricTemplateId, params, "Above $2000");
         assertEq(questionId, bytes32("fakeMetricQuestionId"));
     }
 
@@ -101,6 +93,6 @@ contract CFMRealityAdapterWithMockTest is Test {
         });
 
         vm.expectRevert(); // Should revert with empty outcomes
-        realityAdapter.askDecisionQuestion(params);
+        realityAdapter.askDecisionQuestion(decisionTemplateId, params);
     }
 }

--- a/test/DecisionMarketFactory.t.sol
+++ b/test/DecisionMarketFactory.t.sol
@@ -43,15 +43,17 @@ contract TestERC20 is ERC20 {
 }
 
 contract DecisionMarketFactoryTest is Test {
+    address owner = address(0x1);
+    address user = address(0x2);
+    uint256 decisionTemplateId = 4242;
+    uint256 metricTemplateId = 2424;
+
     FlatCFMFactory public factory;
     FlatCFMRealityAdapter public oracleAdapter;
     ConditionalTokens public conditionalTokens;
     FakeRealityETH public fakeRealityETH; // Instance of Reality_v3
     Wrapped1155Factory public wrapped1155Factory;
     IERC20 public collateralToken;
-
-    address owner = address(0x1);
-    address user = address(0x2);
 
     // Shared outcomeNames array.
     string[] public outcomeNames;
@@ -72,9 +74,8 @@ contract DecisionMarketFactoryTest is Test {
         // Deploy the Wrapped1155Factory contract.
         wrapped1155Factory = new Wrapped1155Factory();
         // Deploy the RealityAdapter with Reality_v3.
-        oracleAdapter = new FlatCFMRealityAdapter(
-            IRealityETH(address(fakeRealityETH)), address(0x00), 4242, 2424, 1000, 10000000000
-        );
+        oracleAdapter =
+            new FlatCFMRealityAdapter(IRealityETH(address(fakeRealityETH)), address(0x00), 1000, 10000000000);
 
         // Deploy the collateral token.
         collateralToken = new TestERC20();
@@ -125,7 +126,9 @@ contract DecisionMarketFactoryTest is Test {
         // Create the market with the shared outcomeNames array.
         vm.prank(owner);
         vm.recordLogs();
-        FlatCFM createdMarket = factory.create(decisionQuestionParams, conditionalQuestionParams, collateralToken);
+        FlatCFM createdMarket = factory.create(
+            decisionTemplateId, metricTemplateId, decisionQuestionParams, conditionalQuestionParams, collateralToken
+        );
         Vm.Log[] memory logs = vm.getRecordedLogs();
         bytes32 eventSignature = keccak256("ConditionalMarketCreated(address,address,uint256,string)");
         address firstCsmAddr;

--- a/test/Integrated.t.sol
+++ b/test/Integrated.t.sol
@@ -60,7 +60,7 @@ contract DeployCoreContractsBase is BaseIntegratedTest {
     function setUp() public virtual override {
         super.setUp();
         oracleAdapter = new FlatCFMRealityAdapter(
-            IRealityETH(address(fakeRealityEth)), DUMMY_ARBITRATOR, 2, 1, QUESTION_TIMEOUT, MIN_BOND
+            IRealityETH(address(fakeRealityEth)), DUMMY_ARBITRATOR, QUESTION_TIMEOUT, MIN_BOND
         );
         decisionMarketFactory = new FlatCFMFactory(
             oracleAdapter,
@@ -81,6 +81,9 @@ contract DeployCoreContractsTest is DeployCoreContractsBase {
 }
 
 contract CreateDecisionMarketBase is DeployCoreContractsBase {
+    uint256 decisionTemplateId = 1;
+    uint256 metricTemplateId = 2;
+
     FlatCFMQuestionParams cfmQuestionParams;
     GenericScalarQuestionParams genericScalarQuestionParams;
     CollateralToken public collateralToken;
@@ -117,7 +120,9 @@ contract CreateDecisionMarketBase is DeployCoreContractsBase {
         });
 
         vm.recordLogs();
-        cfm = decisionMarketFactory.create(cfmQuestionParams, genericScalarQuestionParams, collateralToken);
+        cfm = decisionMarketFactory.create(
+            decisionTemplateId, metricTemplateId, cfmQuestionParams, genericScalarQuestionParams, collateralToken
+        );
         recordScalarMarkets();
         vm.label(address(cfm), "DecisionMarket");
         vm.label(address(conditionalMarketA), "ConditionalMarketA");


### PR DESCRIPTION
Previously, template IDs were fixed in the adapter, requiring a new deployment any time the existing templates would not be deemed sufficient.